### PR TITLE
Orphan: Always create a new mongo-client

### DIFF
--- a/createMongoClient.js
+++ b/createMongoClient.js
@@ -2,8 +2,6 @@ const Promise = require('bluebird');
 const uuidv4 = require('uuid/v4');
 const MongoClient = require('mongodb').MongoClient;
 
-let mongoClient;
-
 /**
  * @typedef {Object} CreateMongoClientResponse
  * @property {String} mongoDbUri
@@ -18,15 +16,11 @@ let mongoClient;
  * @returns {Promise.<CreateMongoClientResponse>}
  */
 module.exports = Promise.coroutine(function* createMongoClientHandler({ connectionUri }) {
-  if (mongoClient) {
-    return mongoClient;
-  }
-
   const dbName = `test-db-${uuidv4()}`;
-  mongoClient = new MongoClient();
+  const Client = new MongoClient();
 
   const mongoDbUri = `${connectionUri}/${dbName}`;
-  mongoClient = yield mongoClient.connect(mongoDbUri);
+  const mongoClient = yield Client.connect(mongoDbUri);
 
   return { mongoDbUri, mongoClient };
 });


### PR DESCRIPTION
By caching the mongo-client created in `createMongoClientHandler.js` it
is no longer possible to have multiple test-suites that create their own
mongoClient handling, e.g. https://github.com/FanMilesGmbH/f2-mongo-migrations.

From now on, consumers of said function call will always get a fresh
mongo-client.